### PR TITLE
Fix errors in private dns zones alerts

### DIFF
--- a/Observability_L100/Deploy/DINE_Policies/privateDnsZoneAlerts_definition.bicep
+++ b/Observability_L100/Deploy/DINE_Policies/privateDnsZoneAlerts_definition.bicep
@@ -320,7 +320,7 @@ module QueryVolumeAlert '../../arm/Microsoft.Authorization/policyDefinitions/man
                                                     name: 'QueryVolume'
                                                     metricNamespace: 'Microsoft.Network/privateDnsZones'
                                                     metricName: 'QueryVolume'
-                                                    operator: 'GreaterThanEqualTo'
+                                                    operator: 'GreaterThanOrEqual'
                                                     threshold: 500
                                                     timeAggregation: 'Total'
                                                     criterionType: 'StaticThresholdCriterion'
@@ -421,7 +421,7 @@ module RegistrationCapacityUtilizationAlert '../../arm/Microsoft.Authorization/p
                                     name: '[concat(parameters(\'resourceName\'), \'-RequestsAlert\')]'
                                     location: 'global'
                                     properties: {
-                                        description: 'Metric Alert for KeyVault Requests'
+                                        description: 'Metric Alert for Private DNS Zone Registration Capacity Utilization'
                                         severity: 3
                                         enabled: true
                                         scopes: [


### PR DESCRIPTION
- Fixed error due to time span (PT1H rather than PT5M)
- Fixed GreaterThanEqualTo should be GreaterThanOrEqual
- Fixed description for Private DNS Zone Registration Capacity Utilization alert