### PR TITLE
enhancement convert-bicep-arm.yml

### DIFF
--- a/.github/workflows/convert-bicep-arm.yml
+++ b/.github/workflows/convert-bicep-arm.yml
@@ -2,14 +2,14 @@ name: Convert Policy Definitions from BICEP to ARM
 permissions: write-all
 
 on:
-  push:
-    branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
-  workflow_dispatch: {}
+    types:
+      - closed
 
 jobs:
   build:
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
     - name: Get current date


### PR DESCRIPTION
Automation now only runs when a PR is closed while merged is true.

This prevents premature runs of the conversion automation.