### PR TITLE
42 bug report all three 3 public dns zone dine policies fail

### DIFF
--- a/Observability_L100/Deploy/policyDefinitions/deploy-dnsz_queryvolume_alert.bicep
+++ b/Observability_L100/Deploy/policyDefinitions/deploy-dnsz_queryvolume_alert.bicep
@@ -37,11 +37,11 @@ module QueryVolumeAlert '../../arm/Microsoft.Authorization/policyDefinitions/man
                     existenceCondition: {
                         allOf: [
                             {
-                                field: 'Microsoft.Insights/metricAlerts/criteria.Microsoft.Azure.Monitor.MultipleResourceMultipleMetricCriteria.allOf[*].metricNamespace'
+                                field: 'Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-SingleResourceMultipleMetricCriteria.allOf[*].metricNamespace'
                                 equals: 'Microsoft.Network/dnsZones'
                             }
                             {
-                                field: 'Microsoft.Insights/metricAlerts/criteria.Microsoft.Azure.Monitor.MultipleResourceMultipleMetricCriteria.allOf[*].metricName'
+                                field: 'Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-SingleResourceMultipleMetricCriteria.allOf[*].metricName'
                                 equals: 'QueryVolume'
                             }
                             {
@@ -99,7 +99,7 @@ module QueryVolumeAlert '../../arm/Microsoft.Authorization/policyDefinitions/man
                                                         name: 'QueryVolume'
                                                         metricNamespace: 'Microsoft.Network/dnsZones'
                                                         metricName: 'QueryVolume'
-                                                        operator: 'GreaterThanOrEqual'
+                                                        operator: 'GreaterOrLessThan'
                                                         timeAggregation: 'Total'
                                                         criterionType: 'DynamicThresholdCriterion'
                                                     }

--- a/Observability_L100/Deploy/policyDefinitions/deploy-dnsz_recordsetcapacityutilization_alert.bicep
+++ b/Observability_L100/Deploy/policyDefinitions/deploy-dnsz_recordsetcapacityutilization_alert.bicep
@@ -37,11 +37,11 @@ module RecordSetCapacityUtilizationAlert '../../arm/Microsoft.Authorization/poli
                     existenceCondition: {
                         allOf: [
                             {
-                                field: 'Microsoft.Insights/metricAlerts/criteria.Microsoft.Azure.Monitor.MultipleResourceMultipleMetricCriteria.allOf[*].metricNamespace'
+                                field: 'Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-SingleResourceMultipleMetricCriteria.allOf[*].metricNamespace'
                                 equals: 'Microsoft.Network/dnsZones'
                             }
                             {
-                                field: 'Microsoft.Insights/metricAlerts/criteria.Microsoft.Azure.Monitor.MultipleResourceMultipleMetricCriteria.allOf[*].metricName'
+                                field: 'Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-SingleResourceMultipleMetricCriteria.allOf[*].metricName'
                                 equals: 'RecordSetCapacityUtilization'
                             }
                             {
@@ -94,7 +94,7 @@ module RecordSetCapacityUtilizationAlert '../../arm/Microsoft.Authorization/poli
                                                         name: 'RecordSetCapacityUtilization'
                                                         metricNamespace: 'Microsoft.Network/dnsZones'
                                                         metricName: 'RecordSetCapacityUtilization'
-                                                        operator: 'GreaterThanOrEqual'
+                                                        operator: 'GreaterThan'
                                                         threshold: 90
                                                         timeAggregation: 'Maximum'
                                                         criterionType: 'StaticThresholdCriterion'

--- a/Observability_L100/Deploy/policyDefinitions/deploy-dnsz_recordsetcount_alert.bicep
+++ b/Observability_L100/Deploy/policyDefinitions/deploy-dnsz_recordsetcount_alert.bicep
@@ -37,11 +37,11 @@ module RecordSetCountAlert '../../arm/Microsoft.Authorization/policyDefinitions/
                     existenceCondition: {
                         allOf: [
                             {
-                                field: 'Microsoft.Insights/metricAlerts/criteria.Microsoft.Azure.Monitor.MultipleResourceMultipleMetricCriteria.allOf[*].metricNamespace'
+                                field: 'Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-SingleResourceMultipleMetricCriteria.allOf[*].metricNamespace'
                                 equals: 'Microsoft.Network/dnsZones'
                             }
                             {
-                                field: 'Microsoft.Insights/metricAlerts/criteria.Microsoft.Azure.Monitor.MultipleResourceMultipleMetricCriteria.allOf[*].metricName'
+                                field: 'Microsoft.Insights/metricAlerts/criteria.Microsoft-Azure-Monitor-SingleResourceMultipleMetricCriteria.allOf[*].metricName'
                                 equals: 'RecordSetCount'
                             }
                             {


### PR DESCRIPTION
Implemented the following changes in:


- [Observability_L100/Deploy/policyDefinitions/deploy-dnsz_queryvolume_alert.bicep](https://github.com/Azure/alz-monitor/compare/main...42-bug-report-all-three-3-public-dns-zone-dine-policies-fail#diff-378187370f03b395cf9eab2553582dbae5bc49141c1c881e24149fbc13c89443)
- [...bility_L100/Deploy/policyDefinitions/deploy-dnsz_recordsetcapacityutilization_alert.bicep](https://github.com/Azure/alz-monitor/compare/main...42-bug-report-all-three-3-public-dns-zone-dine-policies-fail#diff-732120dfec405c9a0b25a7e56a4ac39f6322dfd337523591452ded2aa979a298)
- [Observability_L100/Deploy/policyDefinitions/deploy-dnsz_recordsetcount_alert.bicep](https://github.com/Azure/alz-monitor/compare/main...42-bug-report-all-three-3-public-dns-zone-dine-policies-fail#diff-84100a9439a0deb69235b9f8651fdf12b07df3cabed16b9303291efb03af7b5f)

Changes in the PolicyRule.

- metricNamespace changed from MultipleResourceMultipleMetricCriteria to SingleResourceMultipleMetricCriteria.
- metricName changed from MultipleResourceMultipleMetricCriteria to SingleResourceMultipleMetricCriteria.
- QueryVolume to DynamicThresholdCriterion
- Adjusted evaluationFrequency and windowSize to match availability for this metric (windowSize of 5 minutes for example is not available, 1H is smallest possible