### PR TITLE
43 bug report dine deploy activity log azure firewall delete alert policy fails

### DIFF
--- a/src/resources/Microsoft.Authorization/policyDefinitions/deploy-activitylog-AzureFirewall-Del.bicep
+++ b/src/resources/Microsoft.Authorization/policyDefinitions/deploy-activitylog-AzureFirewall-Del.bicep
@@ -48,8 +48,8 @@ module ActivityLogFirewallDeleteAlert '../../arm/Microsoft.Authorization/policyD
                 details: {
                     roleDefinitionIds: deploymentRoleDefinitionIds
                     type: 'Microsoft.Insights/activityLogAlerts'
-                    name: 'ActivityFirewallDelete'
-                    existenceScope: 'resourcegroup'
+                    name: 'ActivityAzureFirewallDelete'
+                    existenceScope: 'resourceGroup'
                     resourceGroupName: parResourceGroupName
                     deploymentScope: 'subscription'
                     existenceCondition: {


### PR DESCRIPTION
Fixed bug in compliance of Azure Firewall Delete Alert.

Compliance
![image](https://user-images.githubusercontent.com/15944031/217885407-d53a11a1-032e-4554-879f-f884c82c98da.png)

Alert Rule
![image](https://user-images.githubusercontent.com/15944031/217885773-a2170d94-5bec-4ce2-b774-d678bbfe9cf9.png)
