### PR TITLE
event trigger changed to push

### DIFF
--- a/.github/workflows/convert-bicep-arm.yml
+++ b/.github/workflows/convert-bicep-arm.yml
@@ -2,15 +2,13 @@ name: Convert Policy Definitions from BICEP to ARM
 permissions: write-all
 
 on:
-  pull_request:
-    branches: ["main"]
-    types:
-      - closed
+  push:
+    branches: 
+      - "main"
   workflow_dispatch: {}
 
 jobs:
   build:
-    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
       - name: Generate token


### PR DESCRIPTION
Changed event trigger from pull_request to push due to tokens restrictions with pull requests originating from forks.

![image](https://github.com/Azure/alz-monitor/assets/15944031/428cc9ca-6713-467e-aed5-e2185ec12ce6)
