### PR TITLE
Fix alert processing rule defect link to action group

### DIFF
--- a/src/resources/Microsoft.Authorization/policyDefinitions/deploy-alertprocessingrule-deploy.bicep
+++ b/src/resources/Microsoft.Authorization/policyDefinitions/deploy-alertprocessingrule-deploy.bicep
@@ -199,7 +199,7 @@ module AlertProcessingRule '../../arm/Microsoft.Authorization/policyDefinitions/
                               actions: [
                                 {
                                   actiongroupIds: [
-                                    '''[resourceId('Microsoft.Insights/actionGroups','AlzActionGrp')]'''
+                                    '''[concat(subscription().Id, '/resourceGroups/', parameters('ALZMonitorResourceGroupName'), '/providers/Microsoft.Insights/actionGroups/AlzActionGrp')]'''
                                   ]
                                   actionType: 'AddActionGroups'
                                 }


### PR DESCRIPTION
Change resource id for action group referenced in alert processing rule to correct format. Previously the format did not include the resource group since the overall deployment is a subscription deployment. With this change the action group is recognized by the alert processing rule. Referenced [here](https://dev.azure.com/CSUSolEng/Azure%20Landing%20Zones/_workitems/edit/28643/) . Testing evidence from successful deployment can be seen below.

![image](https://github.com/Azure/alz-monitor/assets/22591930/3b9bcf22-3fa6-4765-993b-d23b2656b60b)

![image](https://github.com/Azure/alz-monitor/assets/22591930/7a8921cf-82bc-44d7-8a6a-047c94974a3c)
