### PR TITLE
Updated links to point to working ver guidance

### DIFF
--- a/docs/wiki/Versioning.md
+++ b/docs/wiki/Versioning.md
@@ -1,7 +1,7 @@
 # Versioning for ALZ-Monitor
 
-The primary deliverable of this repo is a collection of Azure Policy initiatives and associated Azure Policy definitions, and as such is versioned in a manner consistent with the [Azure Policy versioning guidance](https://docs.microsoft.com/en-us/azure/governance/policy/concepts/versioning).
+The primary deliverable of this repo is a collection of Azure Policy initiatives and associated Azure Policy definitions, and as such is versioned in a manner consistent with the [Azure Policy versioning guidance](https://github.com/Azure/azure-policy/blob/master/built-in-policies/README.md#versioning).
 
-While this is sufficient for the purposes of individual policies, to further ease adoption of the policies a new release of the repo as a whole will be made available as one or more policies are updated with breaking changes as per the [Azure Policy versioning guidance](https://docs.microsoft.com/en-us/azure/governance/policy/concepts/versioning).
+While this is sufficient for the purposes of individual policies, to further ease adoption of the policies a new release of the repo as a whole will be made available as one or more policies are updated with breaking changes as per the [Azure Policy versioning guidance](https://github.com/Azure/azure-policy/blob/master/built-in-policies/README.md#versioning).
 
 As new versions are released, update guidance will be provided to allow you to update your existing deployments to the new version.


### PR DESCRIPTION
This addresses https://github.com/Azure/alz-monitor/issues/184 broken link.

@jfaurskov I couldn't find a PR change on Azure Policy PG docs for the previous versioning link, can you check this (new link) is the guidance you were wanting linking to? 