### PR TITLE
Fix backup parameters

### DIFF
--- a/infra-as-code/bicep/parameters-complete-management.json
+++ b/infra-as-code/bicep/parameters-complete-management.json
@@ -40,23 +40,8 @@
                 "AATotalJobAlertThreshold": {
                     "value": "20"
                 },
-                "RVBackupHealthAlertSeverity": {
-                    "value": "3"
-                },
-                "RVBackupHealthWindowSize": {
-                    "value": "P1D"
-                },
-                "RVBackupHealthEvaluationFrequency": {
-                    "value": "PT1H"
-                },
                 "RVBackupHealthPolicyEffect": {
-                    "value": "deployIfNotExists"
-                },
-                "RVBackupHealthAlertState": {
-                    "value": "true"
-                },
-                "RVBackupHealthThreshold": {
-                    "value": "20"
+                    "value": "modify"
                 },
                 "StorageAccountAvailabilityAlertSeverity": {
                     "value": "1"


### PR DESCRIPTION
There are orphaned items left in the parameter file for Recovery Vault policy that cause an error message. Plus "RVBackupHealthPolicyEffect" should be set to one of the allowed values (used "modify" here).