### PR TITLE
standard param naming

### DIFF
--- a/infra-as-code/bicep/parameters-complete-management.json
+++ b/infra-as-code/bicep/parameters-complete-management.json
@@ -40,7 +40,7 @@
                 "AATotalJobAlertThreshold": {
                     "value": "20"
                 },
-                "RVBackupHealthPolicyEffect": {
+                "RVBackupHealthMonitorPolicyEffect": {
                     "value": "modify"
                 },
                 "StorageAccountAvailabilityAlertSeverity": {

--- a/src/resources/Microsoft.Authorization/policySetDefinitions/ALZ-MonitorManagement.json
+++ b/src/resources/Microsoft.Authorization/policySetDefinitions/ALZ-MonitorManagement.json
@@ -97,7 +97,7 @@
             "type": "string",
             "defaultValue": "20"
           },
-          "RVBackupHealthPolicyEffect": {
+          "RVBackupHealthMonitorPolicyEffect": {
             "type": "string",
             "defaultValue": "modify",
             "allowedValues": [
@@ -229,11 +229,11 @@
             }
           },
           {
-            "policyDefinitionReferenceId": "ALZ_RVBackupHealth",
+            "policyDefinitionReferenceId": "ALZ_RVBackupHealthMonitor",
             "policyDefinitionId": "[concat('/providers/Microsoft.Management/managementGroups/',managementGroup().name, '/providers/Microsoft.Authorization/policyDefinitions/Deploy_RecoveryVault_BackupHealthMonitor_Alert')]",
             "parameters": {
               "effect": {
-                "value": "[[parameters('RVBackupHealthPolicyEffect')]"
+                "value": "[[parameters('RVBackupHealthMonitorPolicyEffect')]"
               }
             }
           },


### PR DESCRIPTION
Naming of the parameters and policyDefinitionReferenceId was not updated previously.

Now both the management and landingzone parameter files as well as both policy sets have the updated naming for the new rsv alerts.