### PR TITLE
Fix typo in name of ServiceHealthIncident

### DIFF
--- a/src/resources/Microsoft.Authorization/policyDefinitions/deploy-activitylog-ServiceHealth-Incident.bicep
+++ b/src/resources/Microsoft.Authorization/policyDefinitions/deploy-activitylog-ServiceHealth-Incident.bicep
@@ -24,7 +24,7 @@ module ServiceHealthIncidentAlert '../../arm/Microsoft.Authorization/policyDefin
          description: 'Policy to Deploy Service Health Incident Alert'
         location: policyLocation
         metadata: {
-            version: '1.1.0'
+            version: '1.1.1'
             category: 'Monitoring'
             source: 'https://github.com/Azure/Enterprise-Scale/' 
             alzCloudEnvironments: [ 

--- a/src/resources/Microsoft.Authorization/policyDefinitions/deploy-activitylog-ServiceHealth-Incident.bicep
+++ b/src/resources/Microsoft.Authorization/policyDefinitions/deploy-activitylog-ServiceHealth-Incident.bicep
@@ -217,7 +217,7 @@ module ServiceHealthIncidentAlert '../../arm/Microsoft.Authorization/policyDefin
                                                     {
                                                         type: 'microsoft.insights/activityLogAlerts'
                                                         apiVersion: '2020-10-01'
-                                                        name: 'ServieHealthIncident'
+                                                        name: 'ServiceHealthIncident'
                                                         location: 'global'
                                                         dependsOn: [
                                                             '''[concat(subscription().Id, '/resourceGroups/', parameters('alertResourceGroupName'), '/providers/Microsoft.Insights/actionGroups/AlzActionGrp')]'''

--- a/src/resources/Microsoft.Authorization/policyDefinitions/deploy-activitylog-ServiceHealth-Incident.json
+++ b/src/resources/Microsoft.Authorization/policyDefinitions/deploy-activitylog-ServiceHealth-Incident.json
@@ -268,7 +268,7 @@
                                   {
                                     "type": "microsoft.insights/activityLogAlerts",
                                     "apiVersion": "2020-10-01",
-                                    "name": "ServieHealthIncident",
+                                    "name": "ServiceHealthIncident",
                                     "location": "global",
                                     "dependsOn": [
                                       "[[concat(subscription().Id, '/resourceGroups/', parameters('alertResourceGroupName'), '/providers/Microsoft.Insights/actionGroups/AlzActionGrp')]"


### PR DESCRIPTION
Fixed alert name typo's by changing 'ServieHealthIncident' to 'ServiceHealthIncident' in the following files:
- deploy-activitylog-ServiceHealth-Incident.bicep
- deploy-activitylog-ServiceHealth-Incident.json