### PR TITLE
Fixing typos and remediation issues with data disk latency and network alerts

### DIFF
--- a/src/resources/Microsoft.Authorization/policyDefinitions/deploy-vm-HeartBeat_alert.bicep
+++ b/src/resources/Microsoft.Authorization/policyDefinitions/deploy-vm-HeartBeat_alert.bicep
@@ -259,7 +259,7 @@ module HeartBeatAlert '../../arm/Microsoft.Authorization/policyDefinitions/manag
             failingPeriods: {
                 type: 'String'
                 metadata:{
-                    disaplayname: 'Failing Periods'
+                    displayName: 'Failing Periods'
                     description: 'Number of failing periods before alert is fired'
                 }
                 defaultValue: parFailingPeriods

--- a/src/resources/Microsoft.Authorization/policyDefinitions/deploy-vm-HeartBeat_alert.json
+++ b/src/resources/Microsoft.Authorization/policyDefinitions/deploy-vm-HeartBeat_alert.json
@@ -317,7 +317,7 @@
               "failingPeriods": {
                 "type": "String",
                 "metadata": {
-                  "disaplayname": "Failing Periods",
+                  "displayName": "Failing Periods",
                   "description": "Number of failing periods before alert is fired"
                 },
                 "defaultValue": "[parameters('parFailingPeriods')]"

--- a/src/resources/Microsoft.Authorization/policyDefinitions/deploy-vm-NetworkIn_alert.bicep
+++ b/src/resources/Microsoft.Authorization/policyDefinitions/deploy-vm-NetworkIn_alert.bicep
@@ -87,7 +87,7 @@ param parComputersToInclude array = [
      
 ]
 
-param parNetworkInterfacetToInclude array = [
+param parNetworkInterfacesToInclude array = [
     '*'
 ]
 
@@ -292,7 +292,7 @@ module VMNetwrokInAlert '../../arm/Microsoft.Authorization/policyDefinitions/man
                     description: 'Array of Network Interface to be monitored'
                 }
 
-                defaultValue: parNetworkInterfacetToInclude
+                defaultValue: parNetworkInterfacesToInclude
 
             }
             computersToInclude:{
@@ -345,7 +345,7 @@ module VMNetwrokInAlert '../../arm/Microsoft.Authorization/policyDefinitions/man
                
                             {
                                 field: 'Microsoft.Insights/scheduledQueryRules/displayName'
-                                equals: '[concat(subscription().displayName, \'-VMHighNetwrokInAlert\')]'
+                                equals: '[concat(subscription().displayName, \'-VMHighNetworkInAlert\')]'
                             }
                             {
                                 field: 'Microsoft.Insights/scheduledqueryrules/scopes[*]'
@@ -425,7 +425,7 @@ module VMNetwrokInAlert '../../arm/Microsoft.Authorization/policyDefinitions/man
                                         type:'array'
 
                                     }
-                                    networkInterfaceToInclude: {
+                                    networkInterfacesToInclude: {
                                         type:'array'
 
                                     }
@@ -487,7 +487,7 @@ module VMNetwrokInAlert '../../arm/Microsoft.Authorization/policyDefinitions/man
                                                             criteria: {
                                                                 allOf: [
                                                                     {
-                                                                        query: 'InsightsMetrics| where Origin == "vm.azm.ms"| where Namespace == "Network" and Name == "ReadBytesPerSecond"| | extend NetworkInterface=tostring(todynamic(Tags)["vm.azm.ms/networkDeviceId"])|summarize AggregatedValue = avg(Val) by bin(TimeGenerated, 15m), Computer, _ResourceId, NetworkInterface'
+                                                                        query: 'InsightsMetrics| where Origin == "vm.azm.ms"| where Namespace == "Network" and Name == "ReadBytesPerSecond"| extend NetworkInterface=tostring(todynamic(Tags)["vm.azm.ms/networkDeviceId"])|summarize AggregatedValue = avg(Val) by bin(TimeGenerated, 15m), Computer, _ResourceId, NetworkInterface'
                                                                         metricMeasureColumn: 'AggregatedValue'
                                                                         threshold: '[parameters(\'threshold\')]'
                                                                         operator: '[parameters(\'operator\')]'

--- a/src/resources/Microsoft.Authorization/policyDefinitions/deploy-vm-NetworkIn_alert.json
+++ b/src/resources/Microsoft.Authorization/policyDefinitions/deploy-vm-NetworkIn_alert.json
@@ -132,7 +132,7 @@
         "*"
       ]
     },
-    "parNetworkInterfacetToInclude": {
+    "parNetworkInterfacesToInclude": {
       "type": "array",
       "defaultValue": [
         "*"
@@ -348,7 +348,7 @@
                   "displayname": "Network Interface to be included to be monitored",
                   "description": "Array of Network Interface to be monitored"
                 },
-                "defaultValue": "[parameters('parNetworkInterfacetToInclude')]"
+                "defaultValue": "[parameters('parNetworkInterfacesToInclude')]"
               },
               "computersToInclude": {
                 "type": "array",
@@ -394,7 +394,7 @@
                     "allOf": [
                       {
                         "field": "Microsoft.Insights/scheduledQueryRules/displayName",
-                        "equals": "[[concat(subscription().displayName, '-VMHighNetwrokInAlert')]"
+                        "equals": "[[concat(subscription().displayName, '-VMHighNetworkInAlert')]"
                       },
                       {
                         "field": "Microsoft.Insights/scheduledqueryrules/scopes[*]",
@@ -466,7 +466,7 @@
                           "computersToInclude": {
                             "type": "array"
                           },
-                          "networkInterfaceToInclude": {
+                          "networkInterfacesToInclude": {
                             "type": "array"
                           }
                         },
@@ -526,7 +526,7 @@
                                       "criteria": {
                                         "allOf": [
                                           {
-                                            "query": "InsightsMetrics| where Origin == \"vm.azm.ms\"| where Namespace == \"Network\" and Name == \"ReadBytesPerSecond\"| | extend NetworkInterface=tostring(todynamic(Tags)[\"vm.azm.ms/networkDeviceId\"])|summarize AggregatedValue = avg(Val) by bin(TimeGenerated, 15m), Computer, _ResourceId, NetworkInterface",
+                                            "query": "InsightsMetrics| where Origin == \"vm.azm.ms\"| where Namespace == \"Network\" and Name == \"ReadBytesPerSecond\"| extend NetworkInterface=tostring(todynamic(Tags)[\"vm.azm.ms/networkDeviceId\"])|summarize AggregatedValue = avg(Val) by bin(TimeGenerated, 15m), Computer, _ResourceId, NetworkInterface",
                                             "metricMeasureColumn": "AggregatedValue",
                                             "threshold": "[[parameters('threshold')]",
                                             "operator": "[[parameters('operator')]",

--- a/src/resources/Microsoft.Authorization/policyDefinitions/deploy-vm-NetworkOut_alert.bicep
+++ b/src/resources/Microsoft.Authorization/policyDefinitions/deploy-vm-NetworkOut_alert.bicep
@@ -87,7 +87,7 @@ param parComputersToInclude array = [
      
 ]
 
-param parNetworkInterfacetToInclude array = [
+param parNetworkInterfacesToInclude array = [
     '*'
 ]
 
@@ -287,7 +287,7 @@ module VMNetworkOutAlert '../../arm/Microsoft.Authorization/policyDefinitions/ma
             computersToInclude:{
                 type: 'array'
                 metadata:{
-                    displayname:'Disks to be included to be monitored'
+                    displayname:'Computers to be included to be monitored'
                     description: 'Array of Computer to be monitored'
                 }
 
@@ -301,7 +301,7 @@ module VMNetworkOutAlert '../../arm/Microsoft.Authorization/policyDefinitions/ma
                     description: 'Array of Network Interface to be monitored'
                 }
 
-                defaultValue: parNetworkInterfacetToInclude
+                defaultValue: parNetworkInterfacesToInclude
 
             }
 
@@ -342,7 +342,7 @@ module VMNetworkOutAlert '../../arm/Microsoft.Authorization/policyDefinitions/ma
                
                             {
                                 field: 'Microsoft.Insights/scheduledQueryRules/displayName'
-                                equals: '[concat(subscription().displayName, \'-VMHighNetwrokInAlert\')]'
+                                equals: '[concat(subscription().displayName, \'-VMHighNetworkOutAlert\')]'
                             }
                             {
                                 field: 'Microsoft.Insights/scheduledqueryrules/scopes[*]'
@@ -422,7 +422,7 @@ module VMNetworkOutAlert '../../arm/Microsoft.Authorization/policyDefinitions/ma
                                         type:'array'
 
                                     }
-                                    networkInterfaceToInclude: {
+                                    networkInterfacesToInclude: {
                                         type:'array'
 
                                     }
@@ -469,7 +469,7 @@ module VMNetworkOutAlert '../../arm/Microsoft.Authorization/policyDefinitions/ma
                                                         name: '[concat(subscription().displayName, \'-VMHighNetworkOutAlert\')]'
                                                         location: '[parameters(\'alertResourceGroupLocation\')]'
                                                         properties: {
-                                                            displayName: '[concat(subscription().displayName, \'-VMHighNetworOutAlert\')]'
+                                                            displayName: '[concat(subscription().displayName, \'-VMHighNetworkOutAlert\')]'
                                                             description: 'Log Alert for Virtual Machine NetworkOut'
                                                             severity: '[parameters(\'severity\')]'
                                                             enabled: '[parameters(\'enabled\')]'

--- a/src/resources/Microsoft.Authorization/policyDefinitions/deploy-vm-NetworkOut_alert.json
+++ b/src/resources/Microsoft.Authorization/policyDefinitions/deploy-vm-NetworkOut_alert.json
@@ -132,7 +132,7 @@
         "*"
       ]
     },
-    "parNetworkInterfacetToInclude": {
+    "parNetworkInterfacesToInclude": {
       "type": "array",
       "defaultValue": [
         "*"
@@ -345,7 +345,7 @@
               "computersToInclude": {
                 "type": "array",
                 "metadata": {
-                  "displayname": "Disks to be included to be monitored",
+                  "displayname": "Computers to be included to be monitored",
                   "description": "Array of Computer to be monitored"
                 },
                 "defaultValue": "[parameters('parComputersToInclude')]"
@@ -356,7 +356,7 @@
                   "displayname": "Network Interface to be included to be monitored",
                   "description": "Array of Network Interface to be monitored"
                 },
-                "defaultValue": "[parameters('parNetworkInterfacetToInclude')]"
+                "defaultValue": "[parameters('parNetworkInterfacesToInclude')]"
               },
               "effect": {
                 "type": "String",
@@ -394,7 +394,7 @@
                     "allOf": [
                       {
                         "field": "Microsoft.Insights/scheduledQueryRules/displayName",
-                        "equals": "[[concat(subscription().displayName, '-VMHighNetwrokInAlert')]"
+                        "equals": "[[concat(subscription().displayName, '-VMHighNetworkOutAlert')]"
                       },
                       {
                         "field": "Microsoft.Insights/scheduledqueryrules/scopes[*]",
@@ -466,7 +466,7 @@
                           "computersToInclude": {
                             "type": "array"
                           },
-                          "networkInterfaceToInclude": {
+                          "networkInterfacesToInclude": {
                             "type": "array"
                           }
                         },

--- a/src/resources/Microsoft.Authorization/policyDefinitions/deploy-vm-OSDiskSpace_alert.bicep
+++ b/src/resources/Microsoft.Authorization/policyDefinitions/deploy-vm-OSDiskSpace_alert.bicep
@@ -276,7 +276,7 @@ module VMOSDiskSpaceAlert '../../arm/Microsoft.Authorization/policyDefinitions/m
             failingPeriods: {
                 type: 'String'
                 metadata:{
-                    disaplayname: 'Failing Periods'
+                    displayName: 'Failing Periods'
                     description: 'Number of failing periods before alert is fired'
                 }
                 defaultValue: parFailingPeriods

--- a/src/resources/Microsoft.Authorization/policyDefinitions/deploy-vm-OSDiskSpace_alert.json
+++ b/src/resources/Microsoft.Authorization/policyDefinitions/deploy-vm-OSDiskSpace_alert.json
@@ -330,7 +330,7 @@
               "failingPeriods": {
                 "type": "String",
                 "metadata": {
-                  "disaplayname": "Failing Periods",
+                  "displayName": "Failing Periods",
                   "description": "Number of failing periods before alert is fired"
                 },
                 "defaultValue": "[parameters('parFailingPeriods')]"

--- a/src/resources/Microsoft.Authorization/policyDefinitions/deploy-vm-OSDiskreadLatency_alert.bicep
+++ b/src/resources/Microsoft.Authorization/policyDefinitions/deploy-vm-OSDiskreadLatency_alert.bicep
@@ -276,7 +276,7 @@ module VMOSDiskreadLatencyAlert '../../arm/Microsoft.Authorization/policyDefinit
             failingPeriods: {
                 type: 'String'
                 metadata:{
-                    disaplayname: 'Failing Periods'
+                    displayName: 'Failing Periods'
                     description: 'Number of failing periods before alert is fired'
                 }
                 defaultValue: parFailingPeriods

--- a/src/resources/Microsoft.Authorization/policyDefinitions/deploy-vm-OSDiskreadLatency_alert.json
+++ b/src/resources/Microsoft.Authorization/policyDefinitions/deploy-vm-OSDiskreadLatency_alert.json
@@ -330,7 +330,7 @@
               "failingPeriods": {
                 "type": "String",
                 "metadata": {
-                  "disaplayname": "Failing Periods",
+                  "displayName": "Failing Periods",
                   "description": "Number of failing periods before alert is fired"
                 },
                 "defaultValue": "[parameters('parFailingPeriods')]"

--- a/src/resources/Microsoft.Authorization/policyDefinitions/deploy-vm-OSDiskwriteLatency_alert.bicep
+++ b/src/resources/Microsoft.Authorization/policyDefinitions/deploy-vm-OSDiskwriteLatency_alert.bicep
@@ -276,7 +276,7 @@ module VMOSDiskwriteLatencyAlert '../../arm/Microsoft.Authorization/policyDefini
             failingPeriods: {
                 type: 'String'
                 metadata:{
-                    disaplayname: 'Failing Periods'
+                    displayName: 'Failing Periods'
                     description: 'Number of failing periods before alert is fired'
                 }
                 defaultValue: parFailingPeriods

--- a/src/resources/Microsoft.Authorization/policyDefinitions/deploy-vm-OSDiskwriteLatency_alert.json
+++ b/src/resources/Microsoft.Authorization/policyDefinitions/deploy-vm-OSDiskwriteLatency_alert.json
@@ -330,7 +330,7 @@
               "failingPeriods": {
                 "type": "String",
                 "metadata": {
-                  "disaplayname": "Failing Periods",
+                  "displayName": "Failing Periods",
                   "description": "Number of failing periods before alert is fired"
                 },
                 "defaultValue": "[parameters('parFailingPeriods')]"

--- a/src/resources/Microsoft.Authorization/policyDefinitions/deploy-vm-dataDiskSpace_alert.bicep
+++ b/src/resources/Microsoft.Authorization/policyDefinitions/deploy-vm-dataDiskSpace_alert.bicep
@@ -275,7 +275,7 @@ module VMdataDiskSpaceAlert '../../arm/Microsoft.Authorization/policyDefinitions
             failingPeriods: {
                 type: 'String'
                 metadata:{
-                    disaplayname: 'Failing Periods'
+                    displayName: 'Failing Periods'
                     description: 'Number of failing periods before alert is fired'
                 }
                 defaultValue: parFailingPeriods
@@ -283,7 +283,7 @@ module VMdataDiskSpaceAlert '../../arm/Microsoft.Authorization/policyDefinitions
             evaluationPeriods: {
                 type: 'String'
                 metadata:{
-                    disaplayname: 'Evaluation Periods'
+                    displayName: 'Evaluation Periods'
                     description: 'The number of aggregated lookback points.'
                 }
                 defaultValue: parEvaluationPeriods

--- a/src/resources/Microsoft.Authorization/policyDefinitions/deploy-vm-dataDiskSpace_alert.json
+++ b/src/resources/Microsoft.Authorization/policyDefinitions/deploy-vm-dataDiskSpace_alert.json
@@ -323,7 +323,7 @@
               "failingPeriods": {
                 "type": "String",
                 "metadata": {
-                  "disaplayname": "Failing Periods",
+                  "displayName": "Failing Periods",
                   "description": "Number of failing periods before alert is fired"
                 },
                 "defaultValue": "[parameters('parFailingPeriods')]"
@@ -331,7 +331,7 @@
               "evaluationPeriods": {
                 "type": "String",
                 "metadata": {
-                  "disaplayname": "Evaluation Periods",
+                  "displayName": "Evaluation Periods",
                   "description": "The number of aggregated lookback points."
                 },
                 "defaultValue": "[parameters('parEvaluationPeriods')]"

--- a/src/resources/Microsoft.Authorization/policyDefinitions/deploy-vm-dataDiskreadLatency_alert.bicep
+++ b/src/resources/Microsoft.Authorization/policyDefinitions/deploy-vm-dataDiskreadLatency_alert.bicep
@@ -275,7 +275,7 @@ module VMdataDiskReadLatencyAlert '../../arm/Microsoft.Authorization/policyDefin
             failingPeriods: {
                 type: 'String'
                 metadata:{
-                    disaplayname: 'Failing Periods'
+                    displayName: 'Failing Periods'
                     description: 'Number of failing periods before alert is fired'
                 }
                 defaultValue: parFailingPeriods
@@ -471,10 +471,10 @@ module VMdataDiskReadLatencyAlert '../../arm/Microsoft.Authorization/policyDefin
                                                     {
                                                         type: 'Microsoft.Insights/scheduledQueryRules'
                                                         apiVersion: '2022-08-01-preview'
-                                                        name: '[concat(subscription().displayName, \'-VMHighdataDiskReadLatencyAlert\')]'
+                                                        name: '[concat(subscription().displayName, \'-VMLowdataDiskReadLatencyAlert\')]'
                                                         location: '[parameters(\'alertResourceGroupLocation\')]'
                                                         properties: {
-                                                            displayName: '[concat(subscription().displayName, \'-VMHighdataDiskReadLatencyAlert\')]'
+                                                            displayName: '[concat(subscription().displayName, \'-VMLowdataDiskReadLatencyAlert\')]'
                                                             description: 'Log Alert for Virtual Machine dataDiskReadLatency'
                                                             severity: '[parameters(\'severity\')]'
                                                             enabled: '[parameters(\'enabled\')]'

--- a/src/resources/Microsoft.Authorization/policyDefinitions/deploy-vm-dataDiskreadLatency_alert.json
+++ b/src/resources/Microsoft.Authorization/policyDefinitions/deploy-vm-dataDiskreadLatency_alert.json
@@ -329,7 +329,7 @@
               "failingPeriods": {
                 "type": "String",
                 "metadata": {
-                  "disaplayname": "Failing Periods",
+                  "displayName": "Failing Periods",
                   "description": "Number of failing periods before alert is fired"
                 },
                 "defaultValue": "[parameters('parFailingPeriods')]"
@@ -508,10 +508,10 @@
                                   {
                                     "type": "Microsoft.Insights/scheduledQueryRules",
                                     "apiVersion": "2022-08-01-preview",
-                                    "name": "[[concat(subscription().displayName, '-VMHighdataDiskReadLatencyAlert')]",
+                                    "name": "[[concat(subscription().displayName, '-VMLowdataDiskReadLatencyAlert')]",
                                     "location": "[[parameters('alertResourceGroupLocation')]",
                                     "properties": {
-                                      "displayName": "[[concat(subscription().displayName, '-VMHighdataDiskReadLatencyAlert')]",
+                                      "displayName": "[[concat(subscription().displayName, '-VMLowdataDiskReadLatencyAlert')]",
                                       "description": "Log Alert for Virtual Machine dataDiskReadLatency",
                                       "severity": "[[parameters('severity')]",
                                       "enabled": "[[parameters('enabled')]",

--- a/src/resources/Microsoft.Authorization/policyDefinitions/deploy-vm-dataDiskwriteLatency_alert.bicep
+++ b/src/resources/Microsoft.Authorization/policyDefinitions/deploy-vm-dataDiskwriteLatency_alert.bicep
@@ -275,7 +275,7 @@ module VMdataDiskWriteLatencyAlert '../../arm/Microsoft.Authorization/policyDefi
             failingPeriods: {
                 type: 'String'
                 metadata:{
-                    disaplayname: 'Failing Periods'
+                    displayName: 'Failing Periods'
                     description: 'Number of failing periods before alert is fired'
                 }
                 defaultValue: parFailingPeriods
@@ -471,10 +471,10 @@ module VMdataDiskWriteLatencyAlert '../../arm/Microsoft.Authorization/policyDefi
                                                     {
                                                         type: 'Microsoft.Insights/scheduledQueryRules'
                                                         apiVersion: '2022-08-01-preview'
-                                                        name: '[concat(subscription().displayName, \'-VMHighdataDiskWriteLatencyAlert\')]'
+                                                        name: '[concat(subscription().displayName, \'-VMLowdataDiskWriteLatencyAlert\')]'
                                                         location: '[parameters(\'alertResourceGroupLocation\')]'
                                                         properties: {
-                                                            displayName: '[concat(subscription().displayName, \'-VMHighdataDiskWriteLatencyAlert\')]'
+                                                            displayName: '[concat(subscription().displayName, \'-VMLowdataDiskWriteLatencyAlert\')]'
                                                             description: 'Log Alert for Virtual Machine dataDiskWriteLatency'
                                                             severity: '[parameters(\'severity\')]'
                                                             enabled: '[parameters(\'enabled\')]'

--- a/src/resources/Microsoft.Authorization/policyDefinitions/deploy-vm-dataDiskwriteLatency_alert.json
+++ b/src/resources/Microsoft.Authorization/policyDefinitions/deploy-vm-dataDiskwriteLatency_alert.json
@@ -329,7 +329,7 @@
               "failingPeriods": {
                 "type": "String",
                 "metadata": {
-                  "disaplayname": "Failing Periods",
+                  "displayName": "Failing Periods",
                   "description": "Number of failing periods before alert is fired"
                 },
                 "defaultValue": "[parameters('parFailingPeriods')]"
@@ -508,10 +508,10 @@
                                   {
                                     "type": "Microsoft.Insights/scheduledQueryRules",
                                     "apiVersion": "2022-08-01-preview",
-                                    "name": "[[concat(subscription().displayName, '-VMHighdataDiskWriteLatencyAlert')]",
+                                    "name": "[[concat(subscription().displayName, '-VMLowdataDiskWriteLatencyAlert')]",
                                     "location": "[[parameters('alertResourceGroupLocation')]",
                                     "properties": {
-                                      "displayName": "[[concat(subscription().displayName, '-VMHighdataDiskWriteLatencyAlert')]",
+                                      "displayName": "[[concat(subscription().displayName, '-VMLowdataDiskWriteLatencyAlert')]",
                                       "description": "Log Alert for Virtual Machine dataDiskWriteLatency",
                                       "severity": "[[parameters('severity')]",
                                       "enabled": "[[parameters('enabled')]",


### PR DESCRIPTION
Fixing typos on alert policy definitions for:
- data disk latency
- network

Fixing issue with the network alerts not getting created as part of policy remediation